### PR TITLE
Encode graph route query params to fix DOM XSS in dashboard links

### DIFF
--- a/src/views/home.js
+++ b/src/views/home.js
@@ -101,7 +101,7 @@ function dashboardGraphControls(graphWindow, graphMode) {
 }
 
 function dashboardGraphRoute(graphWindow, graphMode) {
-  return `#/?window=${graphWindow}&mode=${graphMode}`;
+  return `#/?window=${encodeUrlPart(graphWindow)}&mode=${encodeUrlPart(graphMode)}`;
 }
 
 function poolHashrateChart(rows, graphWindow) {


### PR DESCRIPTION
### Motivation
- The dashboard route builder interpolated attacker-controlled graph query values directly into `href` strings that are later assigned to `innerHTML`, enabling a reflected DOM XSS when crafted hash parameters break out of the attribute context.

### Description
- URL-encode graph query parameters by changing `dashboardGraphRoute` to use `encodeUrlPart(graphWindow)` and `encodeUrlPart(graphMode)` when building the `#/?window=...&mode=...` fragment in `src/views/home.js`.

### Testing
- Ran `npm run test:unit`, which succeeded with all unit suites passing.
- Ran `npm test`, where unit suites passed but the e2e/static build phase failed due to an external `esbuild` fetch returning `403 Forbidden` in this environment, so full e2e execution could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1682fc9740832181897ed6fad0dac6)