### PR TITLE
Cache coin symbol counts and refactor duplicate-symbol detection in pool.js

### DIFF
--- a/src/pool.js
+++ b/src/pool.js
@@ -1,6 +1,8 @@
 import { XMR_PORT } from "./constants.js";
 import { isFiniteNumber } from "./format.js";
 
+const coinSymbolCountsCache = new WeakMap();
+
 function byPort(values, port) {
   if (!values || typeof values !== "object") return undefined;
   if (Object.hasOwn(values, port)) return values[port];
@@ -93,13 +95,26 @@ export function coinRouteId(poolStats = {}, port) {
 
 function hasDuplicateCoinSymbol(poolStats = {}, symbol) {
   const wanted = coinRouteSlug(symbol);
-  let count = 0;
+  if (!wanted) return false;
+  return getCoinSymbolCounts(poolStats).get(wanted) > 1;
+}
+
+function getCoinSymbolCounts(poolStats = {}) {
+  const coinsRef = poolStats?.coins;
+  if (!coinsRef || typeof coinsRef !== "object") return new Map();
+
+  const cached = coinSymbolCountsCache.get(poolStats);
+  if (cached?.coinsRef === coinsRef) return cached.counts;
+
+  const counts = new Map();
   for (const coin of coinStatsRows(poolStats)) {
     const metadata = coinMetadata(poolStats, coin.p) || {};
-    if (coinRouteSlug(metadata.symbol || coin.s) === wanted) count += 1;
-    if (count > 1) return true;
+    const key = coinRouteSlug(metadata.symbol || coin.s);
+    if (!key) continue;
+    counts.set(key, (counts.get(key) || 0) + 1);
   }
-  return false;
+  coinSymbolCountsCache.set(poolStats, { coinsRef, counts });
+  return counts;
 }
 
 function routeLabel(value) {


### PR DESCRIPTION
### Motivation
- Improve performance when resolving duplicate coin symbols by avoiding repeated scans of `poolStats.coins` for each lookup.
- Ensure stable duplicate detection when `poolStats.coins` reference hasn't changed by caching computed symbol counts.
- Handle empty/invalid inputs early to avoid unnecessary work.

### Description
- Introduced a `WeakMap` named `coinSymbolCountsCache` to cache symbol count maps keyed by the `poolStats` object.
- Refactored `hasDuplicateCoinSymbol` to early-return when the slug is empty and to consult cached counts via a new `getCoinSymbolCounts` function.
- Implemented `getCoinSymbolCounts` to compute a `Map` of slug -> count from `coinStatsRows(poolStats)`, cache it with the `coins` reference as `coinsRef`, and return the counts.
- Updated counting logic to skip empty slugs and to use the cached counts for duplicate checks (`counts.get(wanted) > 1`).

### Testing
- Ran the test suite with `npm test`, which passed successfully.
- Exercised coin routing and duplicate detection logic through unit tests covering `coinRouteId`, `coinRouteSlug`, and `hasDuplicateCoinSymbol`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1714379898832195bbe2e56d8853a6)